### PR TITLE
Validate scene data before import

### DIFF
--- a/PlayCanvas/PCImporter.cs
+++ b/PlayCanvas/PCImporter.cs
@@ -305,7 +305,12 @@ namespace Assets.Editor.PlayCanvas {
                 EditorApplication.delayCall += async () => {
                     try {
                         LoadSceneDataFromJsonFile(entityJsonPath);
-                        
+
+                        if (sceneData?.root == null) {
+                            Debug.LogError("Scene data not loaded or invalid. Aborting import.");
+                            return;
+                        }
+
                         stats = new SceneStatistics();
                         CollectSceneStats(sceneData.root, ref stats);
                         


### PR DESCRIPTION
## Summary
- fix `NullReferenceException` in PCImporter by validating scene data before running stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406705238883289da9d6c4c7c270e7